### PR TITLE
feat: удаление видео из tg при восстановлении

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ downloads/*
 !.gitkeep
 *.db
 user_data_tiktok.json
+result.json

--- a/atp/check_availability.py
+++ b/atp/check_availability.py
@@ -15,7 +15,10 @@ from atp import crud
 from atp.database import get_db_session
 from atp.models import Video
 from atp.settings import CHECK_INTERVAL_DAYS
-from atp.telegram_notifier import delete_message, send_video_deleted_notification
+from atp.telegram_notifier import (
+    handle_video_restoration,
+    send_video_deleted_notification,
+)
 from atp.ytdlp import NetworkError, check_video_availability
 
 
@@ -54,7 +57,7 @@ def check_video_batch() -> None:
                     print(f"Video {video.id} has been restored!")
                     if video.message_id:
                         print(f"Deleting message {video.message_id}")
-                        delete_message(video.message_id)
+                        handle_video_restoration(video)
                     crud.update_video_message_id(db, video.id, None)
                     crud.update_video_status(db, video.id, "success")
                     restored_count += 1

--- a/atp/crud.py
+++ b/atp/crud.py
@@ -56,6 +56,23 @@ def update_video_status(
     return False
 
 
+def update_video_message_id(db: Session, video_id: str, message_id: int | None) -> bool:
+    """Обновляет ID сообщения видео в базе данных.
+
+    :param db: Сессия базы данных
+    :param video_id: ID видео
+    :param message_id: ID сообщения
+
+    :return: True если успешно, False если видео не найдено
+    """
+    db_video = db.query(Video).filter(Video.id == video_id).first()
+    if db_video:
+        db_video.message_id = message_id
+        db.commit()
+        return True
+    return False
+
+
 def update_video_last_checked(db: Session, video_id: str) -> bool:
     """Обновляет время последней проверки видео на текущее.
 
@@ -84,7 +101,7 @@ def get_videos_to_check(db: Session, limit: int) -> list[Video]:
     """
     return (
         db.query(Video)
-        .filter(Video.status == "success")
+        .filter(Video.status.in_(["success", "deleted"]))
         .order_by(Video.last_checked)
         .limit(limit)
         .all()

--- a/atp/download.py
+++ b/atp/download.py
@@ -8,7 +8,7 @@
 
 import os
 
-from atp.crud import get_all_videos
+from atp import crud
 from atp.database import get_db_session
 from atp.settings import DOWNLOADS_DIR
 from atp.ytdlp import download_video
@@ -21,7 +21,7 @@ def download() -> None:
     db = get_db_session()
 
     try:
-        videos = get_all_videos(db, status="new")
+        videos = crud.get_all_videos(db, status="new")
         print(f"Found {len(videos)} new videos")
 
         if not videos:
@@ -38,7 +38,7 @@ def download() -> None:
                 print(f"Failed to download video {video.id}")
 
         print(f"Downloaded {success_count}/{len(videos)} videos")
-        if new_left := get_all_videos(db, status="new"):
+        if new_left := crud.get_all_videos(db, status="new"):
             print(f"{len(new_left)} videos with status `new` remaining")
 
     except Exception as e:

--- a/atp/import_from_file.py
+++ b/atp/import_from_file.py
@@ -12,7 +12,7 @@ import json
 import os
 from datetime import datetime
 
-from atp.crud import add_video_to_db
+from atp import crud
 from atp.database import get_db_session, run_migrations
 from atp.download import download
 from atp.settings import IMPORT_FAVORITE_VIDEOS, IMPORT_LIKED_VIDEOS, TIKTOK_DATA_FILE
@@ -82,7 +82,7 @@ def import_from_file() -> None:
                     + f"Import videos: {added_count: >{len(videos) % 10}}/{len(videos)}",
                     flush=True,
                 )
-                add_video_to_db(db, video["id"], video["date"])  # TODO: make faster
+                crud.add_video_to_db(db, video["id"], video["date"])  # TODO: make faster
                 added_count += 1
             except Exception as e:
                 print(f"Error importing video: {e}")

--- a/atp/import_from_tiktok.py
+++ b/atp/import_from_tiktok.py
@@ -13,7 +13,7 @@ import math
 from TikTokApi import TikTokApi
 from TikTokApi.exceptions import EmptyResponseException, InvalidResponseException
 
-from atp.crud import add_video_to_db, get_all_videos
+from atp import crud
 from atp.database import get_db_session
 from atp.download import download
 from atp.settings import MS_TOKEN, TIKTOK_USER
@@ -24,7 +24,7 @@ async def import_from_tiktok() -> None:
     async with TikTokApi() as api:
         db = get_db_session()
 
-        videos = get_all_videos(db)
+        videos = crud.get_all_videos(db)
         if not videos:
             print("No videos in DB. Please import using import_from_file.py")
             # Удалить чтобы импортировать все видео из тиктока а не файла (дольше и только лайкнутые без сохранённых)
@@ -47,7 +47,7 @@ async def import_from_tiktok() -> None:
 
                 if video.id not in video_ids:
                     print(f"Import video {video.id}")
-                    add_video_to_db(db, video.id, video.create_time)
+                    crud.add_video_to_db(db, video.id, video.create_time)
 
                 if len(new_videos) >= 20 and set(new_videos[-20:]).issubset(video_ids):
                     # Все 20 последних видео уже есть в БД, ливаем

--- a/atp/migrations/versions/007_add_message_id_column.py
+++ b/atp/migrations/versions/007_add_message_id_column.py
@@ -1,0 +1,75 @@
+"""add message id column
+
+Revision ID: 007
+Create Date: 2025-06-04
+
+"""
+
+import json
+import os
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.orm import Session
+
+from atp import crud
+
+# revision identifiers, used by Alembic.
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+def load_messages():
+    TELEGRAM_MESSAGES_FILE = "./result.json"
+    if not os.path.exists(TELEGRAM_MESSAGES_FILE):
+        print(f"File {TELEGRAM_MESSAGES_FILE} does not exist")
+        return []
+    with open(TELEGRAM_MESSAGES_FILE, "r") as f:
+        data = json.load(f)
+        messages = []
+        for message in data["messages"]:
+            if message.get("type") == "message":
+                message_text = "".join(
+                    entity.get("text", "") for entity in message["text_entities"]
+                )
+                lines = message_text.strip().split("\n")
+                if len(lines) >= 1:
+                    if len(lines) >= 3:
+                        video_name = lines[1]
+                    else:
+                        video_name = lines[0]
+                    if not video_name:
+                        continue
+                    messages.append({
+                        "id": message["id"],
+                        "text": video_name
+                    })
+        return messages
+
+
+def upgrade():
+    op.add_column("videos", sa.Column("message_id", sa.Integer(), nullable=True))
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    videos = crud.get_all_videos(session, status="deleted")
+    messages = load_messages()
+
+    for message in messages:
+        matched_videos = [
+            video for video in videos
+            if (video.name.strip() if video.name else "") == message["text"].strip()
+        ]
+        if len(matched_videos) == 1:
+            print(f"Found message {message['id']} for video {matched_videos[0].name}")
+            matched_videos[0].message_id = message["id"]
+            session.commit()
+        else:
+            print(f"Found {len(matched_videos)} videos for message {message['id']}")
+
+
+def downgrade():
+    op.drop_column("videos", "message_id")

--- a/atp/models.py
+++ b/atp/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, String
+from sqlalchemy import Column, DateTime, Integer, String
 
 from atp.database import Base
 
@@ -18,6 +18,7 @@ class Video(Base):
     :ivar created_at: Дата создания записи
     :ivar updated_at: Дата последнего обновления записи
     :ivar last_checked: Дата последней проверки доступности
+    :ivar message_id: ID сообщения об удалении видео
     """
 
     __tablename__ = "videos"
@@ -33,6 +34,7 @@ class Video(Base):
         DateTime, default=lambda: datetime.now(), onupdate=lambda: datetime.now()
     )
     last_checked: Optional[datetime] = Column(DateTime, nullable=True)
+    message_id: Optional[int] = Column(Integer, nullable=True)
 
     def __repr__(self) -> str:
         """Строковое представление объекта Video.

--- a/atp/telegram_notifier.py
+++ b/atp/telegram_notifier.py
@@ -39,7 +39,8 @@ def send_video_deleted_notification(video: Video) -> bool:
 
         if response.status_code == 200:
             print("Telegram notification sent successfully.")
-            return True
+            message_id = response.json().get('result', {}).get('message_id')
+            return message_id
         else:
             print(f"Failed to send Telegram notification: {response.text}")
             return False
@@ -77,4 +78,35 @@ def send_message(text: str) -> bool:
 
     except Exception as e:
         print(f"Exception occurred while sending Telegram message: {e}")
+        return False
+
+
+def delete_message(message_id: int) -> bool:
+    """Удаляет сообщение из Telegram.
+
+    :param message_id: ID сообщения для удаления
+
+    :return: True если сообщение было успешно удалено, False в противном случае
+    """
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+        print("Error: Telegram parameters not configured (token or chat ID)")
+        return False
+
+    try:
+        data = {
+            "chat_id": TELEGRAM_CHAT_ID,
+            "message_id": message_id,
+        }
+        url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/deleteMessage"
+        response = requests.post(url, data=data)
+
+        if response.status_code == 200:
+            print("Telegram message deleted successfully.")
+            return True
+        else:
+            print(f"Failed to delete Telegram message: {response.text}")
+            return False
+
+    except Exception as e:
+        print(f"Exception occurred while deleting Telegram message: {e}")
         return False


### PR DESCRIPTION
### Новая крутая фича:
1. Теперь при публикации видео в tg, id сообщения сохраняется в базу
2. Помимо активных видео теперь проверяются ещё и удалённые (т.к. их могут восстановить)
3. При восстановлении видео, оно удаляется из tg по id из базы

#### Теперь в канале будут оставаться только реально удалённые видео


Если у вас уже есть удалённые видео в tg (маловероятно), предусмотрен импорт id сообщений:
1. Скачайте историю чата из tg
2. Поместите `result.json` в корень
3. Eсли используете docker, добавьте `- ./result.json:/app/result.json:ro` в volume
4. Запустите проект
5. Можно удалить файл и volume